### PR TITLE
Convert all labels to strings

### DIFF
--- a/streams.yaml
+++ b/streams.yaml
@@ -18,22 +18,22 @@ proxima.erc20.eth-main.events.1_0:
   description: "all erc20 events on eth-main"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc20.eth-goerli.events.1_0:
   description: "all erc20 events on eth-goerli"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc20.polygon-main.events.1_0:
   description: "all erc20 events on polygon-main"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc20.polygon-mumbai.events.1_0:
   description: "all erc20 events on polygon-mumbai"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc20.eth-main.events.2_0:
   description: "all erc20 events on eth-main"
   labels:
@@ -59,22 +59,22 @@ proxima.erc721.eth-main.events.1_0:
   description: "all erc721 events on eth-main"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc721.eth-goerli.events.1_0:
   description: "all erc721 events on eth-goerli"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc721.polygon-main.events.1_0:
   description: "all erc721 events on polygon-main"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc721.polygon-mumbai.events.1_0:
   description: "all erc721 events on polygon-mumbai"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.erc721.eth-main.events.2_0:
   description: "all erc721 events on eth-main"
   labels:
@@ -113,7 +113,7 @@ proxima.mangrove.polygon-main.domain-events.0_1:
   description: "domain events emitted by mangrove smart contracts at 0x2f5a51b09044754c7c8b1a9dee29e046b5432038 on polygon-main"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 
 proxima.mangrove.polygon-main.domain-events.0_3:
   description: "domain events emitted by mangrove smart contracts at 0x2f5a51b09044754c7c8b1a9dee29e046b5432038 on polygon-main"
@@ -153,22 +153,22 @@ proxima.mangrove.polygon-mumbai.domain-events.0_5:
   description: "domain events emitted by mangrove smart contracts (multiple version) on polygon-mumbai"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.mangrove.polygon-mumbai.tokens.0_2:
   description: "ERC20 tokens used by mangrove smart contracts on polygon-mumbai"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.mangrove.polygon-mumbai.domain-events.0_3:
   description: "domain events emitted by mangrove smart contracts (multiple version) on polygon-mumbai"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 proxima.mangrove.polygon-mumbai.tokens.0_1:
   description: "ERC20 tokens used by mangrove smart contracts on polygon-mumbai"
   labels:
     encoding: "json"
-    legacy: true
+    legacy: "true"
 
 proxima.univ2.eth-main.gen-dex-amm.0_1:
   description: "Uniswap V2 exchange events in generic AMM DEX format"


### PR DESCRIPTION
Go client has a strongly defined schema so all "labels" have to be mappings from string to a string